### PR TITLE
Symfony 4.2 support without deprecated. TreeBuilder set root node.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,11 +12,11 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ruvents_doctrine_fixes');
+        $treeBuilder = new TreeBuilder('ruvents_doctrine_fixes');
 
         /** @noinspection PhpUndefinedMethodInspection */
-        $rootNode
+        $treeBuilder
+            ->getRootNode()
             ->useAttributeAsKey('connection')
             ->prototype('array')
                 ->children()

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "symfony/http-kernel": "^3.0 || ^4.0",
-        "symfony/config": "^3.0 || ^4.0",
-        "symfony/dependency-injection": "^3.0 || ^4.0",
-        "symfony/yaml": "^3.0 || ^4.0",
+        "php": "^7.1.3",
+        "symfony/http-kernel": "^4.2",
+        "symfony/config": "^4.2",
+        "symfony/dependency-injection": "^4.2",
+        "symfony/yaml": "^4.2",
         "doctrine/dbal": "^2.5"
     },
     "require-dev": {


### PR DESCRIPTION
Calling TreeBuilder with root node in the constructor is recommended with Symfony 4.2.